### PR TITLE
Updating CI/CD pipeline to track code coverage on a PR

### DIFF
--- a/testApp/.github/workflows/github-actions-demo.yml
+++ b/testApp/.github/workflows/github-actions-demo.yml
@@ -1,18 +1,13 @@
-name: GitHub Actions Demo
-run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+name: Jest Unit Testing and Lint
+run-name: ${{ github.actor }} has initiated a Pull Request
 on: [push]
 jobs:
-  Explore-GitHub-Actions:
+  jest-unit_test-lint:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Check out repository code
-        uses: actions/checkout@v3
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: List files in the repository
-        run: |
-          ls ${{ github.workspace }}
-      - run: echo "🍏 This job's status is ${{ job.status }}."
+      - uses: actions/checkout@v2
+      - run: |
+              npm ci
+              npm run build
+              npm run test
+              npm run lint

--- a/testApp/__tests__/app.spec.js
+++ b/testApp/__tests__/app.spec.js
@@ -1,0 +1,21 @@
+import { mount } from '@vue/test-utils'
+import App from './../src/App.vue'
+
+describe('App', () => {
+    // Inspect the raw component options
+    it('does not have data', () => {
+      expect(typeof App.data).toBe('undefined')
+    })
+  })
+
+  describe('Mounted App', () => {
+    const wrapper = mount(App);
+  
+    test('does a wrapper exist', () => {
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    it('has a router-link', () => {
+        expect(wrapper.find('router-link').exists()).toBe(true)
+      })
+  })

--- a/testApp/jest.config.js
+++ b/testApp/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    preset: '@vue/cli-plugin-unit-jest'
+}


### PR DESCRIPTION
This commit will cause a PR be rejected upon a failed test (can be updated to track total coverage)